### PR TITLE
fix ver exception&support to download vscode's platform dep plugins

### DIFF
--- a/vscode-ext.py
+++ b/vscode-ext.py
@@ -55,6 +55,9 @@ def version_serial(version):
         r = v[2].split("-", maxsplit=1)
         t = (int(v[0]), int(v[1]), int(r[0]), r[1])
         return t
+    elif "x" in v[2]:
+        t = (int(v[0]), int(v[1]), 0)
+        return t
     else:
         return tuple(map(int, v))
 
@@ -282,8 +285,12 @@ class Extension:
         vsix = set()
         vsix.add(find_version_vsix(extension, "linux-x64"))
         vsix.add(find_version_vsix(extension, "linux-arm64"))
+        vsix.add(find_version_vsix(extension, "linux-armhf"))
         vsix.add(find_version_vsix(extension, "alpine-x64"))
         vsix.add(find_version_vsix(extension, "alpine-arm64"))
+        vsix.add(find_version_vsix(extension, "win32-x64"))
+        vsix.add(find_version_vsix(extension, "win32-ia32"))
+        vsix.add(find_version_vsix(extension, "win32-arm64"))
         return vsix
 
 


### PR DESCRIPTION
1. fix version exception

example)
version: {'version': '0.3.4', 'flags': 'validated', 'lastUpdated': '2016-10-19T06:42:02.363Z', 'properties': [{'key': 'Microsoft.VisualStudio.Services.Branding.Color', 'value': '#37699A'}, {'key': 'Microsoft.VisualStudio.Services.Branding.Theme', 'value': 'dark'}, {'key': 'Microsoft.VisualStudio.Services.Links.Repository', 'value': 'https://github.com/editorconfig/editorconfig-vscode.git'}, {'key': 'Microsoft.VisualStudio.Services.Links.Getstarted', 'value': 'https://github.com/editorconfig/editorconfig-vscode.git'}, {'key': 'Microsoft.VisualStudio.Services.Links.Support', 'value': 'https://github.com/editorconfig/editorconfig-vscode/issues'}, {'key': 'Microsoft.VisualStudio.Services.Links.Learn', 'value': 'https://github.com/editorconfig/editorconfig-vscode/blob/master/README.md'}, {'key': 'Microsoft.VisualStudio.Services.Links.Source', 'value': 'https://github.com/editorconfig/editorconfig-vscode.git'}, {'key': 'Microsoft.VisualStudio.Code.Engine', 'value': '^1.6.x'}], 'assetUri': 'https://editorconfig.gallerycdn.vsassets.io/extensions/editorconfig/editorconfig/0.3.4/1476859315661', 'fallbackAssetUri': 'https://editorconfig.gallery.vsassets.io/_apis/public/gallery/publisher/EditorConfig/extension/EditorConfig/0.3.4/assetbyname'}

EditorConfig's Microsoft.VisualStudio.Code.Engine value is 1.6.x

So, Replace with zero if the version name contains x.

2. support to download some vscode's platform-dependent plugins support to download some vscode's platform-dependent plugins such as linux-arm32, windows32, windows x64, windows arm64