### PR TITLE
Modify 'Location' key exception

### DIFF
--- a/vscode-app.py
+++ b/vscode-app.py
@@ -16,6 +16,8 @@ def download(dest_dir: Path, urls, version):
 
     for url in urls:
         r = session.head(url)
+        if "Location" not in r.headers:
+            continue
         real_url = r.headers["Location"]
         name = Path(real_url).name
         file = dest_dir / name


### PR DESCRIPTION
Modify 'Location' key exception

example) Some response header doesn't contain 'Location' {'Date': 'Thu, 30 Nov 2023 00:00:00 GMT', 'Content-Type': 'text/plain; charset=utf-8',
 'Content-Length': '9', 'Connection': 'keep-alive', 'Access-Control-Allow-Origin': '*',
 'Strict-Transport-Security': 'max-age=31536000; includeSubDomains',
 'request-context': 'appId=cid-v1:****-****-****', 'X-Powered-By': 'Express',
 'X-Content-Type-Options': 'nosniff', 'X-Source-Commit': '****',
 'x-azure-ref': '****-****', 'X-Cache': 'CONFIG_NOCACHE'}